### PR TITLE
Fix diffnormals filter output.

### DIFF
--- a/lidar_euclidean_cluster_detect/nodes/lidar_euclidean_cluster_detect/lidar_euclidean_cluster_detect.cpp
+++ b/lidar_euclidean_cluster_detect/nodes/lidar_euclidean_cluster_detect/lidar_euclidean_cluster_detect.cpp
@@ -832,7 +832,7 @@ void differenceNormalsSegmentation(const pcl::PointCloud<pcl::PointXYZ>::Ptr in_
   // Apply filter
   cond_removal.filter(*diffnormals_cloud_filtered);
 
-  pcl::copyPointCloud<pcl::PointNormal, pcl::PointXYZ>(*diffnormals_cloud, *out_cloud_ptr);
+  pcl::copyPointCloud<pcl::PointNormal, pcl::PointXYZ>(*diffnormals_cloud_filtered, *out_cloud_ptr);
 }
 
 void removePointsUpTo(const pcl::PointCloud<pcl::PointXYZ>::Ptr in_cloud_ptr,


### PR DESCRIPTION
<!--
For support requests, please ask at ROS Answers: https://answers.ros.org/questions/ask/?tags=autoware, make sure to use the "autoware" tag.
For general questions and design discussion, please use the Autoware Discourse category: https://discourse.ros.org/c/autoware
Not sure if this is the right repository? Open an issue on https://github.com/Autoware-AI/autoware.ai/issues
For bug fix pull requests, please fill out the information below.
Be as detailed as possible.
-->

## Bug fix

### Fix applied
<!-- Describe in detail the approach taken, tools used, etc. to identify the cause of the bug and what was done to fix it. -->
Change the output of `differenceNormalsSegmentation` function in `lidar_euclidean_cluster_detect/nodes/lidar_euclidean_cluster_detect/lidar_euclidean_cluster_detect.cpp` to the `filtered` result.