### PR TITLE
Fix a rare out of bound exception of the ray_ground_filter

### DIFF
--- a/points_preprocessor/nodes/ray_ground_filter/ray_ground_filter.cpp
+++ b/points_preprocessor/nodes/ray_ground_filter/ray_ground_filter.cpp
@@ -353,7 +353,13 @@ void RayGroundFilter::ConvertAndTrim(const sensor_msgs::PointCloud2::Ptr in_tran
       theta -= 360;
     }
 
-    auto radial_div = (size_t)floor(theta / radial_divider_angle_);
+    // radial_divider_angle_ is computed so that
+    // 360 / radial_divider_angle_ = radial_dividers_num_
+    // Even though theta < 360, rounding error may make it so that
+    // theta / radial_divider_angle_ >= radial_dividers_num_
+    // which gives a radial_div one past the end. The modulo is here to fix
+    // this rare case, wrapping the bad radial_div back to the first one.
+    auto radial_div = (size_t)floor(theta / radial_divider_angle_) % radial_dividers_num_;
     out_radial_ordered_clouds->at(radial_div).emplace_back(z, radius, point_start_ptr);
   }  // end for
 


### PR DESCRIPTION
## Bug fix

### Fixed bug
With some particular cylindrical coordinates, a point can have a theta such as
floor(theta/radial_divider_angle) == out_radial_ordered_clouds.size()
This create an out of bound when the point is inserted in the out_radial_ordered_clouds vector at the index returned by floor().

This has been discovered while using the [kitti's lidar dataset](http://www.cvlibs.net/datasets/kitti/eval_object.php?obj_benchmark=3d) when running the frame 162

### Fix applied
Given that out_radial_ordered_clouds.size() = radial_dividers_num_, adding a modulo with this size to the floor's result ensure that any out of bound values returned by floor get wrapped to correct values : 

radial_div = (size_t)floor(theta / radial_divider_angle_) % radial_dividers_num_

out_radial_ordered_clouds is a vector containing angular segments around the (0,0) point. The one-past-the-end segment is thus the same as the first segment, hence wrapping being allowed.