### PR TITLE
Use apollo pretrained models on lidar_apollo_cnn_seg_detect, add parameter to normalize lidar intensity data

### DIFF
--- a/lidar_apollo_cnn_seg_detect/README.md
+++ b/lidar_apollo_cnn_seg_detect/README.md
@@ -13,7 +13,7 @@ $ cd caffe
 ```
 Follow instructions from [Installing Caffe from source](http://caffe.berkeleyvision.org/installation.html).
 
-* **Use offical Make compilation procedure**. 
+* **Use offical Make compilation procedure**.
 * Do not use thirdparty CMake setup.
 
 Compile and create distributable:
@@ -23,6 +23,17 @@ $ make distribute
 ```
 
 **Recompile Autoware to build the node.**
+
+## The Pretrained model
+
+Use this link to download the pretrained model from Baidu:
+
+https://github.com/ApolloAuto/apollo/tree/v5.5.0/modules/perception/production/data/perception/lidar/models/cnnseg
+
+These two files are needed:
+
+* deploy.prototxt
+* deploy.caffemodel
 
 ## How to launch
 
@@ -48,6 +59,10 @@ Computing Tab -> Detection/ lidar_detector -> `lidar_cnn_baidu_detect`. Configur
 |`score_threshold`|*Double*|Minimum score required as given by the network to include the result (0.-1.)|0.6|
 |`use_gpu`|*Bool*|Whether ot not to use a GPU device|`true`|
 |`gpu_device_id`|*Int*|GPU ID|`0`|
+|`width`|*Int*|Width of the 2d cluster|`512`|
+|`height`|*Int*|Height of the 2d cluster|`512`|
+|`range`|*Int*|Range for the 2d cluster|`60`|
+|`use_constant_feature`|*Bool*|Use constant model feature (8 features) |`false`|
 
 ## Outputs
 

--- a/lidar_apollo_cnn_seg_detect/README.md
+++ b/lidar_apollo_cnn_seg_detect/README.md
@@ -63,6 +63,7 @@ Computing Tab -> Detection/ lidar_detector -> `lidar_cnn_baidu_detect`. Configur
 |`height`|*Int*|Height of the 2d cluster|`512`|
 |`range`|*Int*|Range for the 2d cluster|`60`|
 |`use_constant_feature`|*Bool*|Use constant model feature (8 features) |`false`|
+|`normalize_lidar_intensity`|*Bool*|Normalize the received lidar intensity data|`false`|
 
 ## Outputs
 

--- a/lidar_apollo_cnn_seg_detect/include/cnn_segmentation.h
+++ b/lidar_apollo_cnn_seg_detect/include/cnn_segmentation.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 Autoware Foundation. All rights reserved.
+ * Copyright 2018-2020 Autoware Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,6 +61,7 @@ private:
   double range_, score_threshold_;
   int width_;
   int height_;
+  bool use_constant_feature_;
   std_msgs::Header message_header_;
   std::string topic_src_;
 

--- a/lidar_apollo_cnn_seg_detect/include/cnn_segmentation.h
+++ b/lidar_apollo_cnn_seg_detect/include/cnn_segmentation.h
@@ -62,6 +62,7 @@ private:
   int width_;
   int height_;
   bool use_constant_feature_;
+  bool normalize_lidar_intensity_;
   std_msgs::Header message_header_;
   std::string topic_src_;
 

--- a/lidar_apollo_cnn_seg_detect/include/feature_generator.h
+++ b/lidar_apollo_cnn_seg_detect/include/feature_generator.h
@@ -31,7 +31,7 @@ public:
   FeatureGenerator(){}
   ~FeatureGenerator(){}
 
-  bool init(caffe::Blob<float>* out_blob, bool use_constant_feature);
+  bool init(caffe::Blob<float>* out_blob, bool use_constant_feature, bool normalize_lidar_intensity);
   void generate(
       const pcl::PointCloud<pcl::PointXYZI>::Ptr& pc_ptr);
 private:
@@ -41,6 +41,8 @@ private:
 
   float min_height_ = 0.0;
   float max_height_ = 0.0;
+
+  bool normalize_lidar_intensity_ = false;
 
   // raw feature data
   float* max_height_data_ = nullptr;

--- a/lidar_apollo_cnn_seg_detect/include/feature_generator.h
+++ b/lidar_apollo_cnn_seg_detect/include/feature_generator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 Autoware Foundation. All rights reserved.
+ * Copyright 2018-2020 Autoware Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ public:
   FeatureGenerator(){}
   ~FeatureGenerator(){}
 
-  bool init(caffe::Blob<float>* out_blob);
+  bool init(caffe::Blob<float>* out_blob, bool use_constant_feature);
   void generate(
       const pcl::PointCloud<pcl::PointXYZI>::Ptr& pc_ptr);
 private:

--- a/lidar_apollo_cnn_seg_detect/launch/lidar_apollo_cnn_seg_detect.launch
+++ b/lidar_apollo_cnn_seg_detect/launch/lidar_apollo_cnn_seg_detect.launch
@@ -10,6 +10,7 @@
   <arg name="height" default="512" />
   <arg name="range" default="60" />
   <arg name="use_constant_feature" default="false"/>
+  <arg name="normalize_lidar_intensity" default="false"/>
 
   <node pkg="lidar_apollo_cnn_seg_detect" type="lidar_apollo_cnn_seg_detect" name="lidar_apollo_cnn_seg_detect_01" output="screen">
     <param name="network_definition_file" value="$(arg network_definition_file)" />
@@ -22,6 +23,7 @@
     <param name="width" value="$(arg width)" />
     <param name="range" value="$(arg range)" />
     <param name="use_constant_feature" value="$(arg use_constant_feature)" />
+    <param name="normalize_lidar_intensity" value="$(arg normalize_lidar_intensity)" />
   </node>
 
   <node pkg="detected_objects_visualizer" type="visualize_detected_objects" name="cluster_detect_visualization_01"

--- a/lidar_apollo_cnn_seg_detect/launch/lidar_apollo_cnn_seg_detect.launch
+++ b/lidar_apollo_cnn_seg_detect/launch/lidar_apollo_cnn_seg_detect.launch
@@ -6,6 +6,10 @@
   <arg name="score_threshold" default="0.6" />
   <arg name="use_gpu" default="true" />
   <arg name="gpu_device_id" default="0" />
+  <arg name="width" default="512" />
+  <arg name="height" default="512" />
+  <arg name="range" default="60" />
+  <arg name="use_constant_feature" default="false"/>
 
   <node pkg="lidar_apollo_cnn_seg_detect" type="lidar_apollo_cnn_seg_detect" name="lidar_apollo_cnn_seg_detect_01" output="screen">
     <param name="network_definition_file" value="$(arg network_definition_file)" />
@@ -14,6 +18,10 @@
     <param name="score_threshold" value="$(arg score_threshold)" />
     <param name="use_gpu" value="$(arg use_gpu)" />
     <param name="gpu_device_id" value="$(arg gpu_device_id)" />
+    <param name="height" value="$(arg height)" />
+    <param name="width" value="$(arg width)" />
+    <param name="range" value="$(arg range)" />
+    <param name="use_constant_feature" value="$(arg use_constant_feature)" />
   </node>
 
   <node pkg="detected_objects_visualizer" type="visualize_detected_objects" name="cluster_detect_visualization_01"

--- a/lidar_apollo_cnn_seg_detect/nodes/cnn_segmentation.cpp
+++ b/lidar_apollo_cnn_seg_detect/nodes/cnn_segmentation.cpp
@@ -63,6 +63,9 @@ bool CNNSegmentation::init()
   private_node_handle.param<bool>("use_constant_feature", use_constant_feature_, false);
   ROS_INFO("[%s] whether to use constant features: %d", __APP_NAME__, use_constant_feature_);
 
+  private_node_handle.param<bool>("normalize_lidar_intensity", normalize_lidar_intensity_, false);
+  ROS_INFO("[%s] whether to normalize lidar intensity data: %d", __APP_NAME__, normalize_lidar_intensity_);
+
   private_node_handle.param<bool>("use_gpu", use_gpu_, false);
   ROS_INFO("[%s] use_gpu: %d", __APP_NAME__, use_gpu_);
 
@@ -123,7 +126,7 @@ bool CNNSegmentation::init()
   }
 
   feature_generator_.reset(new FeatureGenerator());
-  if (!feature_generator_->init(feature_blob_.get(), use_constant_feature_))
+  if (!feature_generator_->init(feature_blob_.get(), use_constant_feature_, normalize_lidar_intensity_))
   {
     ROS_ERROR("[%s] Fail to Initialize feature generator for CNNSegmentation", __APP_NAME__);
     return false;

--- a/lidar_apollo_cnn_seg_detect/nodes/cnn_segmentation.cpp
+++ b/lidar_apollo_cnn_seg_detect/nodes/cnn_segmentation.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 Autoware Foundation. All rights reserved.
+ * Copyright 2018-2020 Autoware Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,7 +49,7 @@ bool CNNSegmentation::init()
   ROS_INFO("[%s] points_src: %s", __APP_NAME__, topic_src_.c_str());
 
   private_node_handle.param<double>("range", range_, 60.);
-  ROS_INFO("[%s] Pretrained Model File: %.2f", __APP_NAME__, range_);
+  ROS_INFO("[%s] range: %.2f", __APP_NAME__, range_);
 
   private_node_handle.param<double>("score_threshold", score_threshold_, 0.6);
   ROS_INFO("[%s] score_threshold: %.2f", __APP_NAME__, score_threshold_);
@@ -59,6 +59,9 @@ bool CNNSegmentation::init()
 
   private_node_handle.param<int>("height", height_, 512);
   ROS_INFO("[%s] height: %d", __APP_NAME__, height_);
+
+  private_node_handle.param<bool>("use_constant_feature", use_constant_feature_, false);
+  ROS_INFO("[%s] whether to use constant features: %d", __APP_NAME__, use_constant_feature_);
 
   private_node_handle.param<bool>("use_gpu", use_gpu_, false);
   ROS_INFO("[%s] use_gpu: %d", __APP_NAME__, use_gpu_);
@@ -120,7 +123,7 @@ bool CNNSegmentation::init()
   }
 
   feature_generator_.reset(new FeatureGenerator());
-  if (!feature_generator_->init(feature_blob_.get()))
+  if (!feature_generator_->init(feature_blob_.get(), use_constant_feature_))
   {
     ROS_ERROR("[%s] Fail to Initialize feature generator for CNNSegmentation", __APP_NAME__);
     return false;
@@ -191,7 +194,11 @@ void CNNSegmentation::test_run()
 
 void CNNSegmentation::run()
 {
-  init();
+  if(this->init()){
+    ROS_INFO("Network init successfully!");
+  }else{
+    ROS_ERROR("Network init fail!!!");
+  }
 
   points_sub_ = nh_.subscribe(topic_src_, 1, &CNNSegmentation::pointsCallback, this);
   points_pub_ = nh_.advertise<sensor_msgs::PointCloud2>("/detection/lidar_detector/points_cluster", 1);

--- a/lidar_apollo_cnn_seg_detect/nodes/feature_generator.cpp
+++ b/lidar_apollo_cnn_seg_detect/nodes/feature_generator.cpp
@@ -16,7 +16,7 @@
 
 #include "feature_generator.h"
 
-bool FeatureGenerator::init(caffe::Blob<float>* out_blob, bool use_constant_feature)
+bool FeatureGenerator::init(caffe::Blob<float>* out_blob, bool use_constant_feature, bool normalize_lidar_intensity)
 {
   out_blob_ = out_blob;
 
@@ -28,6 +28,8 @@ bool FeatureGenerator::init(caffe::Blob<float>* out_blob, bool use_constant_feat
   max_height_ = 5.0;
   CHECK_EQ(width_, height_)
       << "Current implementation version requires input_width == input_height.";
+
+  normalize_lidar_intensity_ = normalize_lidar_intensity;
 
   // set output blob and log lookup table
   if(use_constant_feature){
@@ -134,9 +136,11 @@ void FeatureGenerator::generate(
 
     int idx = map_idx_[i];
     float pz = points[i].z;
-    // kitti dataset of intensify already in (0~1)!!!!!
-    float pi = points[i].intensity / 255.0;
-    // float pi = points[i].intensity;
+    float pi = points[i].intensity;
+    if (normalize_lidar_intensity_)
+    {
+      pi = pi / 255.0;
+    }
     if (max_height_data_[idx] < pz) {
       max_height_data_[idx] = pz;
       top_intensity_data_[idx] = pi;

--- a/lidar_apollo_cnn_seg_detect/nodes/feature_generator.cpp
+++ b/lidar_apollo_cnn_seg_detect/nodes/feature_generator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 Autoware Foundation. All rights reserved.
+ * Copyright 2018-2020 Autoware Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 #include "feature_generator.h"
 
-bool FeatureGenerator::init(caffe::Blob<float>* out_blob)
+bool FeatureGenerator::init(caffe::Blob<float>* out_blob, bool use_constant_feature)
 {
   out_blob_ = out_blob;
 
@@ -30,7 +30,11 @@ bool FeatureGenerator::init(caffe::Blob<float>* out_blob)
       << "Current implementation version requires input_width == input_height.";
 
   // set output blob and log lookup table
-  out_blob_->Reshape(1, 8, height_, width_);
+  if(use_constant_feature){
+    out_blob_->Reshape(1, 8, height_, width_);
+  }else{
+    out_blob_->Reshape(1, 6, height_, width_);
+  }
 
   log_table_.resize(256);
   for (size_t i = 0; i < log_table_.size(); ++i) {
@@ -40,37 +44,44 @@ bool FeatureGenerator::init(caffe::Blob<float>* out_blob)
   float* out_blob_data = nullptr;
   out_blob_data = out_blob_->mutable_cpu_data();
 
+  // the pretrained model inside apollo project don't use the constant feature like direction_data_ and distance_data_
   int channel_index = 0;
   max_height_data_ = out_blob_data + out_blob_->offset(0, channel_index++);
   mean_height_data_ = out_blob_data + out_blob_->offset(0, channel_index++);
   count_data_ = out_blob_data + out_blob_->offset(0, channel_index++);
-  direction_data_ = out_blob_data + out_blob_->offset(0, channel_index++);
+  if(use_constant_feature){
+    direction_data_ = out_blob_data + out_blob_->offset(0, channel_index++);
+  }
   top_intensity_data_ = out_blob_data + out_blob_->offset(0, channel_index++);
   mean_intensity_data_ = out_blob_data + out_blob_->offset(0, channel_index++);
-  distance_data_ = out_blob_data + out_blob_->offset(0, channel_index++);
+  if(use_constant_feature){
+    distance_data_ = out_blob_data + out_blob_->offset(0, channel_index++);
+  }
   nonempty_data_ = out_blob_data + out_blob_->offset(0, channel_index++);
   CHECK_EQ(out_blob_->offset(0, channel_index), out_blob_->count());
 
-  // compute direction and distance features
-  int siz = height_ * width_;
-  std::vector<float> direction_data(siz);
-  std::vector<float> distance_data(siz);
+  if(use_constant_feature){
+    // compute direction and distance features
+    int siz = height_ * width_;
+    std::vector<float> direction_data(siz);
+    std::vector<float> distance_data(siz);
 
-  for (int row = 0; row < height_; ++row) {
-    for (int col = 0; col < width_; ++col) {
-      int idx = row * width_ + col;
-      // * row <-> x, column <-> y
-      float center_x = Pixel2Pc(row, height_, range_);
-      float center_y = Pixel2Pc(col, width_, range_);
-      constexpr double K_CV_PI = 3.1415926535897932384626433832795;
-      direction_data[idx] =
-          static_cast<float>(std::atan2(center_y, center_x) / (2.0 * K_CV_PI));
-      distance_data[idx] =
-          static_cast<float>(std::hypot(center_x, center_y) / 60.0 - 0.5);
+    for (int row = 0; row < height_; ++row) {
+      for (int col = 0; col < width_; ++col) {
+        int idx = row * width_ + col;
+        // * row <-> x, column <-> y
+        float center_x = Pixel2Pc(row, height_, range_);
+        float center_y = Pixel2Pc(col, width_, range_);
+        constexpr double K_CV_PI = 3.1415926535897932384626433832795;
+        direction_data[idx] =
+            static_cast<float>(std::atan2(center_y, center_x) / (2.0 * K_CV_PI));
+        distance_data[idx] =
+            static_cast<float>(std::hypot(center_x, center_y) / 60.0 - 0.5);
+      }
     }
+    caffe::caffe_copy(siz, direction_data.data(), direction_data_);
+    caffe::caffe_copy(siz, distance_data.data(), distance_data_);
   }
-  caffe::caffe_copy(siz, direction_data.data(), direction_data_);
-  caffe::caffe_copy(siz, distance_data.data(), distance_data_);
 
   return true;
 }
@@ -123,7 +134,9 @@ void FeatureGenerator::generate(
 
     int idx = map_idx_[i];
     float pz = points[i].z;
+    // kitti dataset of intensify already in (0~1)!!!!!
     float pi = points[i].intensity / 255.0;
+    // float pi = points[i].intensity;
     if (max_height_data_[idx] < pz) {
       max_height_data_[idx] = pz;
       top_intensity_data_[idx] = pi;


### PR DESCRIPTION
## Bug fix

### Fixed bug
The lidar_apollo_cnn_seg_detect can't be used with the actual provided models from apollo because of a mismatch of the number of feature expected by the node and the number of feature in the model, this change introduces a parameter to switch between the old implementation and the new.
Another parameter is introduced to normalize or not the lidar intensity data, because some dataset provides the intensity data normalized (kitti) and some other not.
