### PR TITLE
Fix the broken link in trafficlight_recognizer/region_tlr_ssd

### DIFF
--- a/trafficlight_recognizer/nodes/region_tlr_ssd/README.md
+++ b/trafficlight_recognizer/nodes/region_tlr_ssd/README.md
@@ -5,7 +5,7 @@
 
 1. Compile Autoware
 
-2. Download and decompress [trained data](http://db3.ertl.jp/autoware/tlr_trained_model/data.tar.bz2)(or use your own) under `Autoware/ros/src/computing/perception/detection/packages/rtrafficlight_recognizer/data`.  
+2. Download and decompress [trained data](https://autoware-ai.s3.us-east-2.amazonaws.com/region_tlr_ssd_trained_weights.tar.bz2)(or use your own) under `Autoware/ros/src/computing/perception/detection/packages/rtrafficlight_recognizer/data`.  
 
    Decompression result will be like followings:
    ```


### PR DESCRIPTION
<!--
For support requests, please ask at ROS Answers: https://answers.ros.org/questions/ask/?tags=autoware, make sure to use the "autoware" tag.
For general questions and design discussion, please use the Autoware Discourse category: https://discourse.ros.org/c/autoware
Not sure if this is the right repository? Open an issue on https://github.com/Autoware-AI/autoware.ai/issues
For bug fix pull requests, please fill out the information below.
Be as detailed as possible.
-->

## Bug fix

### Fixed bug
<!-- Briefly describe the bug being fixed.
If there is a bug report issue for the bug, link to that issue.
If there is not a bug report issue for the bug, create one first and fill out all the required information there, then link to that issue from this bug fix pull request. -->

The link for the model file was unavailable in https://github.com/Autoware-AI/core_perception/tree/master/trafficlight_recognizer/nodes/region_tlr_ssd. 

### Fix applied
<!-- Describe in detail the approach taken, tools used, etc. to identify the cause of the bug and what was done to fix it. -->

This PR updates that link.