### PR TITLE
Fix launch file for vision_darknet_detect

### DIFF
--- a/vision_darknet_detect/launch/vision_yolo2_detect.launch
+++ b/vision_darknet_detect/launch/vision_yolo2_detect.launch
@@ -22,7 +22,7 @@
 
     <node pkg="detected_objects_visualizer" type="visualize_rects" name="yolo2_rects"
           output="screen">
-        <param name="image_src" value="$(arg image_src)"/>
+        <param name="image_src" value="$(arg camera_id)$(arg image_src)"/>
         <param name="image_out" value="/image_rects"/>
         <param name="object_src" value="/detection/image_detector/objects"/> <!-- this is fixed by definition -->
     </node>

--- a/vision_darknet_detect/launch/vision_yolo3_detect.launch
+++ b/vision_darknet_detect/launch/vision_yolo3_detect.launch
@@ -22,7 +22,7 @@
 
   <node pkg="detected_objects_visualizer" type="visualize_rects" name="yolo3_rects"
         output="screen">
-    <param name="image_src" value="$(arg image_src)"/>
+    <param name="image_src" value="$(arg camera_id)$(arg image_src)"/>
     <param name="image_out" value="/image_rects"/>
     <param name="object_src" value="/detection/image_detector/objects"/> <!-- this is fixed by definition -->
   </node>


### PR DESCRIPTION
- Two ros nodes launched by the launch file do not subscribe to the
same rostopic for raw image data. Either one does not get updates
as expected.
- Tested with a rosbag file which publishes raw image data and verified
the results through rviz.

See original MR for more details: https://gitlab.com/astuff/autoware.ai/core_perception/-/merge_requests/12