### PR TITLE
Add a configurable parameter for ndt_matching output tf pose name

### DIFF
--- a/lidar_localizer/launch/ndt_matching.launch
+++ b/lidar_localizer/launch/ndt_matching.launch
@@ -13,6 +13,7 @@
   <arg name="use_local_transform" default="false" />
   <arg name="sync" default="false" />
   <arg name="output_log_data" default="false" />
+  <arg name="output_tf_frame_id" default="base_link"/>
   <arg name="gnss_reinit_fitness" default="500.0" />
 
   <node pkg="lidar_localizer" type="ndt_matching" name="ndt_matching" output="log">
@@ -27,6 +28,7 @@
     <param name="get_height" value="$(arg get_height)" />
     <param name="use_local_transform" value="$(arg use_local_transform)" />
     <param name="output_log_data" value="$(arg output_log_data)" />
+    <param name="output_tf_frame_id" value="$(arg output_tf_frame_id)" />
     <param name="gnss_reinit_fitness" value="$(arg gnss_reinit_fitness)" />
     <remap from="/points_raw" to="/sync_drivers/points_raw" if="$(arg sync)" />
   </node>

--- a/lidar_localizer/nodes/ndt_matching/ndt_matching.cpp
+++ b/lidar_localizer/nodes/ndt_matching/ndt_matching.cpp
@@ -225,6 +225,7 @@ static bool _use_imu = false;
 static bool _use_odom = false;
 static bool _imu_upside_down = false;
 static bool _output_log_data = false;
+static std::string _output_tf_frame_id = "base_link";
 
 static std::string _imu_topic = "/imu_raw";
 
@@ -1367,14 +1368,13 @@ static void points_callback(const sensor_msgs::PointCloud2::ConstPtr& input)
     // Send TF "/base_link" to "/map"
     transform.setOrigin(tf::Vector3(current_pose.x, current_pose.y, current_pose.z));
     transform.setRotation(current_q);
-    //    br.sendTransform(tf::StampedTransform(transform, current_scan_time, "/map", "/base_link"));
     if (_use_local_transform == true)
     {
-      br.sendTransform(tf::StampedTransform(local_transform * transform, current_scan_time, "/map", "/base_link"));
+      br.sendTransform(tf::StampedTransform(local_transform * transform, current_scan_time, "map", _output_tf_frame_id));
     }
     else
     {
-      br.sendTransform(tf::StampedTransform(transform, current_scan_time, "/map", "/base_link"));
+      br.sendTransform(tf::StampedTransform(transform, current_scan_time, "map", _output_tf_frame_id));
     }
 
     matching_end = std::chrono::system_clock::now();
@@ -1560,6 +1560,7 @@ int main(int argc, char** argv)
   private_nh.getParam("imu_upside_down", _imu_upside_down);
   private_nh.getParam("imu_topic", _imu_topic);
   private_nh.param<double>("gnss_reinit_fitness", _gnss_reinit_fitness, 500.0);
+  private_nh.getParam("output_tf_frame_id", _output_tf_frame_id);
 
   if (nh.getParam("localizer", _localizer) == false)
   {


### PR DESCRIPTION
Currently, ndt_matching publishes a transform from frame map to base_link.
We'd like to make it configurable so other nodes can possibly publish the same transform from map to base_link without clashing.
For example, if ekf_localizer is enabled to smooth out the ndt_pose generated by ndt_matching node, we'd like to let ekf_localizer
publish that transform.

See original MR for more details: https://gitlab.com/astuff/autoware.ai/core_perception/-/merge_requests/20