### PR TITLE
Add individual launch files for can_status_translater and localization remapping

### DIFF
--- a/autoware_connector/launch/can_status_translator.launch
+++ b/autoware_connector/launch/can_status_translator.launch
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<launch>
+  <node pkg="autoware_connector" type="can_status_translator" name="can_status_translator" output="screen" />
+</launch>

--- a/autoware_connector/launch/localization_connect.launch
+++ b/autoware_connector/launch/localization_connect.launch
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<launch>
+  <arg name="pose_stamped_topic" default="" />
+  <arg name="twist_stamped_topic" default="" />
+
+  <node pkg="topic_tools" type="relay" name="pose_relay" output="log" args="$(arg pose_stamped_topic) /current_pose"/>
+  <node pkg="topic_tools" type="relay" name="vel_relay" output="log" args="$(arg twist_stamped_topic) /current_velocity"/>
+</launch>


### PR DESCRIPTION
The existing vel_pose_connect.launch file launches the can_status_translator which has no purpose to us other than publishing linear_velocity_viz for use in RViz.
The new launch files provided in this PR give us the same easy method of remapping topics without launching the can_status_translator.

See original MR for more details: https://gitlab.com/astuff/autoware.ai/core_perception/-/merge_requests/37