### PR TITLE
Fix ray_ground_filter Namespacing

### DIFF
--- a/points_preprocessor/include/points_preprocessor/ray_ground_filter/ray_ground_filter.h
+++ b/points_preprocessor/include/points_preprocessor/ray_ground_filter/ray_ground_filter.h
@@ -42,7 +42,8 @@ class RayGroundFilter
 {
 private:
   std::shared_ptr<autoware_health_checker::HealthChecker> health_checker_ptr_;
-  ros::NodeHandle node_handle_;
+  ros::NodeHandle nh_;
+  ros::NodeHandle pnh_;
   ros::Subscriber points_node_sub_;
   ros::Subscriber config_node_sub_;
   ros::Publisher groundless_points_pub_;

--- a/points_preprocessor/launch/ray_ground_filter.launch
+++ b/points_preprocessor/launch/ray_ground_filter.launch
@@ -1,6 +1,6 @@
 <!-- Launch file for Ray Ground Filter -->
 <launch>
-  <arg name="input_point_topic" default="/points_raw" />  <!-- input_point_topic, ground filtering will be performed over the pointcloud in this topic. -->
+  <arg name="input_point_topic" default="points_raw" />  <!-- input_point_topic, ground filtering will be performed over the pointcloud in this topic. -->
   <arg name="base_frame" default="base_link" />  <!-- Coordinate system to perform transform (default base_link) -->
   <arg name="clipping_height" default="2.0" />  <!-- Remove Points above this height value (default 2.0 meters) -->
   <arg name="min_point_distance" default="1.85" />  <!-- Removes Points closer than this distance from the sensor origin (default 1.85 meters) -->
@@ -10,8 +10,8 @@
   <arg name="general_max_slope" default="5" />  <!-- Max Slope of the ground in the entire PointCloud, used when reclassification occurs (default 5 degrees)-->
   <arg name="min_height_threshold" default="0.5" />  <!-- Minimum height threshold between points (default 0.05 meters)-->
   <arg name="reclass_distance_threshold" default="0.2" />  <!-- Distance between points at which re classification will occur (default 0.2 meters)-->
-  <arg name="no_ground_point_topic" default="/points_no_ground" />
-  <arg name="ground_point_topic" default="/points_ground" />
+  <arg name="no_ground_point_topic" default="points_no_ground" />
+  <arg name="ground_point_topic" default="points_ground" />
 
   <!-- rosrun points_preprocessor ray_ground_filter -->
   <node pkg="points_preprocessor" type="ray_ground_filter" name="ray_ground_filter" output="log">


### PR DESCRIPTION
Topic names were changed from absolute to relative topics, and the public nodehandle was used to subscribe/advertise topics instead of the private nodehandle.
This makes it much easier to run multiple ray_ground_filters at the same time.

See original MR for more details: https://gitlab.com/astuff/autoware.ai/core_perception/-/merge_requests/38