### PR TITLE
ekf_localizer: Add param for tf frame name

### DIFF
--- a/ekf_localizer/include/ekf_localizer/ekf_localizer.h
+++ b/ekf_localizer/include/ekf_localizer/ekf_localizer.h
@@ -57,7 +57,6 @@ private:
   ros::Subscriber sub_pose_with_cov_;    //!< @brief measurement pose with covariance subscriber
   ros::Subscriber sub_twist_with_cov_;   //!< @brief measurement twist with covariance subscriber
   ros::Timer timer_control_;             //!< @brief time for ekf calculation callback
-  ros::Timer timer_tf_;                  //!< @brief timer to send transform
   tf2_ros::TransformBroadcaster tf_br_;  //!< @brief tf broadcaster
 
   TimeDelayKalmanFilter ekf_;  //!< @brief  extended kalman filter instance.
@@ -66,9 +65,9 @@ private:
   bool show_debug_info_;
   double ekf_rate_;                  //!< @brief  EKF predict rate
   double ekf_dt_;                    //!< @brief  = 1 / ekf_rate_
-  double tf_rate_;                   //!< @brief  tf publish rate
   bool enable_yaw_bias_estimation_;  //!< @brief  for LiDAR mount error. if true, publish /estimate_yaw_bias
   std::string pose_frame_id_;
+  std::string output_frame_id_;
 
   int dim_x_;              //!< @brief  dimension of EKF state
   int extend_state_step_;  //!< @brief  for time delay compensation
@@ -125,9 +124,9 @@ private:
   void timerCallback(const ros::TimerEvent& e);
 
   /**
-   * @brief publish tf for tf_rate [Hz]
+   * @brief publish tf
    */
-  void timerTFCallback(const ros::TimerEvent& e);
+  void broadcastTF();
 
   /**
    * @brief set pose measurement

--- a/ekf_localizer/launch/ekf_localizer.launch
+++ b/ekf_localizer/launch/ekf_localizer.launch
@@ -3,7 +3,6 @@
   <arg name="show_debug_info" default="false"/>
   <arg name="enable_yaw_bias_estimation" default="True"/>
   <arg name="predict_frequency" default="50.0"/>
-  <arg name="tf_rate" default="10.0"/>
   <arg name="extend_state_step" default="50"/>
 
 
@@ -51,12 +50,12 @@
     <remap from="initialpose" to="/initialpose"/>
 
     <param name="pose_frame_id" value="map"/>
+    <param name="output_frame_id" value="base_link"/>
 
     <param name="show_debug_info" value="$(arg show_debug_info)"/>
     <param name="enable_yaw_bias_estimation" value="$(arg enable_yaw_bias_estimation)"/>
 
     <param name="predict_frequency" value="$(arg predict_frequency)"/>
-    <param name="tf_rate" value="$(arg tf_rate)"/>
     <param name="extend_state_step" value="$(arg extend_state_step)"/>
 
     <param name="use_pose_with_covariance" value="$(arg use_pose_with_covariance)"/>

--- a/ekf_localizer/src/ekf_localizer.cpp
+++ b/ekf_localizer/src/ekf_localizer.cpp
@@ -27,10 +27,10 @@ EKFLocalizer::EKFLocalizer() : nh_(""), pnh_("~"), dim_x_(6 /* x, y, yaw, yaw_bi
   pnh_.param("show_debug_info", show_debug_info_, bool(false));
   pnh_.param("predict_frequency", ekf_rate_, double(50.0));
   ekf_dt_ = 1.0 / std::max(ekf_rate_, 0.1);
-  pnh_.param("tf_rate", tf_rate_, double(10.0));
   pnh_.param("enable_yaw_bias_estimation", enable_yaw_bias_estimation_, bool(true));
   pnh_.param("extend_state_step", extend_state_step_, int(50));
-  pnh_.param("pose_frame_id", pose_frame_id_, std::string("/map"));
+  pnh_.param("pose_frame_id", pose_frame_id_, std::string("map"));
+  pnh_.param("output_frame_id", output_frame_id_, std::string("base_link"));
 
   /* pose measurement */
   pnh_.param("pose_additional_delay", pose_additional_delay_, double(0.0));
@@ -70,7 +70,6 @@ EKFLocalizer::EKFLocalizer() : nh_(""), pnh_("~"), dim_x_(6 /* x, y, yaw, yaw_bi
   /* initialize ros system */
 
   timer_control_ = nh_.createTimer(ros::Duration(ekf_dt_), &EKFLocalizer::timerCallback, this);
-  timer_tf_ = nh_.createTimer(ros::Duration(1.0 / tf_rate_), &EKFLocalizer::timerTFCallback, this);
   pub_pose_ = nh_.advertise<geometry_msgs::PoseStamped>("ekf_pose", 1);
   pub_pose_cov_ = nh_.advertise<geometry_msgs::PoseWithCovarianceStamped>("ekf_pose_with_covariance", 1);
   pub_twist_ = nh_.advertise<geometry_msgs::TwistStamped>("ekf_twist", 1);
@@ -183,17 +182,18 @@ void EKFLocalizer::setCurrentResult()
 }
 
 /*
- * timerTFCallback
+ * broadcastTF
  */
-void EKFLocalizer::timerTFCallback(const ros::TimerEvent& e)
+void EKFLocalizer::broadcastTF()
 {
   if (current_ekf_pose_.header.frame_id == "")
+  {
     return;
+  }
 
   geometry_msgs::TransformStamped transformStamped;
-  transformStamped.header.stamp = ros::Time::now();
-  transformStamped.header.frame_id = current_ekf_pose_.header.frame_id;
-  transformStamped.child_frame_id = "ekf_pose";
+  transformStamped.header = current_ekf_pose_.header;
+  transformStamped.child_frame_id = output_frame_id_;
   transformStamped.transform.translation.x = current_ekf_pose_.pose.position.x;
   transformStamped.transform.translation.y = current_ekf_pose_.pose.position.y;
   transformStamped.transform.translation.z = current_ekf_pose_.pose.position.z;
@@ -709,6 +709,8 @@ void EKFLocalizer::publishEstimateResult()
   twist_cov.twist.covariance[35] = P(IDX::WZ, IDX::WZ);
   pub_twist_cov_.publish(twist_cov);
 
+  /* Send transform of pose */
+  broadcastTF();
 
   /* publish yaw bias */
   std_msgs::Float64 yawb;


### PR DESCRIPTION
Added a parameter for the frame name, default is "base_link".
I also noticed the transform was being published on its own loop instead of whenever a new pose was calculated.

See original MR for more details: https://gitlab.com/astuff/autoware.ai/core_perception/-/merge_requests/46