### PR TITLE
Add build warning for ndt_cpu

### DIFF
--- a/ndt_cpu/CMakeLists.txt
+++ b/ndt_cpu/CMakeLists.txt
@@ -46,12 +46,15 @@ set(incs
   include/ndt_cpu/Octree.h
 )
 
-message(WARNING
-"Adding 'EIGEN_DISABLE_UNALIGNED_ARRAY_ASSERT' macro to prevent ndt_matching's runtime error in debug mode.
-  The bug reasons and solutions are written in http://eigen.tuxfamily.org/dox-devel/group__TopicUnalignedArrayAssert.html .
-  This workaround was discussed on https://gitlab.com/autowarefoundation/autoware.ai/core_perception/merge_requests/57 .")
+if(NOT ("${CMAKE_BUILD_TYPE}" STREQUAL "Release"))
+  message(WARNING "Not building for release, performance will be slow")
 
-add_definitions(-DEIGEN_DISABLE_UNALIGNED_ARRAY_ASSERT)
+  message(WARNING
+  "Adding 'EIGEN_DISABLE_UNALIGNED_ARRAY_ASSERT' macro to prevent ndt_matching's runtime error in debug mode.
+    The bug reasons and solutions are written in http://eigen.tuxfamily.org/dox-devel/group__TopicUnalignedArrayAssert.html .
+    This workaround was discussed on https://gitlab.com/autowarefoundation/autoware.ai/core_perception/merge_requests/57 .")
+  add_definitions(-DEIGEN_DISABLE_UNALIGNED_ARRAY_ASSERT)
+endif()
 
 add_library(ndt_cpu ${incs} ${srcs})
 


### PR DESCRIPTION
Added a CMakLists build warning if you aren't building for release.
Also moved the existing additional definition into the if since it only applies to debug builds.

See original MR for more details: https://gitlab.com/astuff/autoware.ai/core_perception/-/merge_requests/48