### PR TITLE
Fix wrong variable assignment in ndt_matching

### DIFF
--- a/lidar_localizer/nodes/ndt_matching/ndt_matching.cpp
+++ b/lidar_localizer/nodes/ndt_matching/ndt_matching.cpp
@@ -313,7 +313,7 @@ static void param_callback(const autoware_config_msgs::ConfigNDT::ConstPtr& inpu
 #endif
 #ifdef USE_PCL_OPENMP
     else if (_method_type == MethodType::PCL_OPENMP)
-      omp_ndt.setStepSize(ndt_res);
+      omp_ndt.setStepSize(step_size);
 #endif
   }
 
@@ -331,7 +331,7 @@ static void param_callback(const autoware_config_msgs::ConfigNDT::ConstPtr& inpu
 #endif
 #ifdef USE_PCL_OPENMP
     else if (_method_type == MethodType::PCL_OPENMP)
-      omp_ndt.setTransformationEpsilon(ndt_res);
+      omp_ndt.setTransformationEpsilon(trans_eps);
 #endif
   }
 
@@ -349,7 +349,7 @@ static void param_callback(const autoware_config_msgs::ConfigNDT::ConstPtr& inpu
 #endif
 #ifdef USE_PCL_OPENMP
     else if (_method_type == MethodType::PCL_OPENMP)
-      omp_ndt.setMaximumIterations(ndt_res);
+      omp_ndt.setMaximumIterations(max_iter);
 #endif
   }
 


### PR DESCRIPTION
## Bug fix

### Fixed bug
Wrong assignment in the parameters of the NDT map variable in the param_callback, for the case where the method type is `PCL_OPENMP.` . Probably a typo from the previous cases.

### Fix applied
Changing the `ndt_res` to:
 -  `step_size`
 -  `trans_eps`
 -  `max_iter`

