### PR TITLE
Fix the bug of publishing incorrect map data

### DIFF
--- a/lidar_localizer/nodes/ndt_mapping/ndt_mapping.cpp
+++ b/lidar_localizer/nodes/ndt_mapping/ndt_mapping.cpp
@@ -785,7 +785,7 @@ static void points_callback(const sensor_msgs::PointCloud2::ConstPtr& input)
   }
 
   sensor_msgs::PointCloud2::Ptr map_msg_ptr(new sensor_msgs::PointCloud2);
-  pcl::toROSMsg(*map_ptr, *map_msg_ptr);
+  pcl::toROSMsg(*map, *map_msg_ptr);
   ndt_map_pub.publish(*map_msg_ptr);
 
   q.setRPY(current_pose.roll, current_pose.pitch, current_pose.yaw);


### PR DESCRIPTION
## Bug fix

### Fixed bug

Fixed the bug of publishing old map data. The bug is at line 788 of ![ndt_mapping.cpp](https://github.com/Autoware-AI/core_perception/blob/master/lidar_localizer/nodes/ndt_mapping/ndt_mapping.cpp).

The link of this issue is ![here](https://github.com/Autoware-AI/core_perception/issues/39).
